### PR TITLE
Change src and dest fields of config struct to path type

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,3 +7,4 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+regex = "1.4.5"

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -1,7 +1,9 @@
+use regex::RegexSet;
 use std::path::PathBuf;
 
 pub struct ConfStruct {
-    pub exclude_patterns: Vec<String>,
+    pub exclude_clearname: Vec<String>,
+    pub exclude_regex: RegexSet,
     pub source: PathBuf,
     pub destination: PathBuf,
     pub help: bool,

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -2,7 +2,7 @@ use regex::RegexSet;
 use std::path::PathBuf;
 
 pub struct ConfStruct {
-    pub exclude_clearname: Vec<String>,
+    pub exclude_strings: Vec<String>,
     pub exclude_regex: RegexSet,
     pub source: PathBuf,
     pub destination: PathBuf,

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -6,5 +6,5 @@ pub struct ConfStruct {
     pub exclude_regex: RegexSet,
     pub source: PathBuf,
     pub destination: PathBuf,
-    pub help: bool,
+    pub verbose: bool,
 }

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -1,6 +1,8 @@
+use std::path::PathBuf;
+
 pub struct ConfStruct {
     pub exclude_patterns: Vec<String>,
-    pub source: String,
-    pub destination: String,
+    pub source: PathBuf,
+    pub destination: PathBuf,
     pub help: bool,
 }


### PR DESCRIPTION
Before, they were simple strings. Rust offers a discrete Path type for
this kind of thing. As Path is dynamically sized, it has to be put in a
Box<>.